### PR TITLE
fix(rayu-web): move clsx and tailwind-merge to dependencies

### DIFF
--- a/rayu-web/package.json
+++ b/rayu-web/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@clerk/nextjs": "latest",
+    "clsx": "^2.1.1",
     "framer-motion": "^12.42.2",
     "lucide-react": "^1.23.0",
     "next": "^15.1.6",
@@ -21,7 +22,8 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-markdown": "^10.1.0",
-    "remark-gfm": "^4.0.1"
+    "remark-gfm": "^4.0.1",
+    "tailwind-merge": "^3.6.0"
   },
   "devDependencies": {
     "@types/jest": "^29.5.14",
@@ -29,10 +31,8 @@
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "autoprefixer": "^10.5.2",
-    "clsx": "^2.1.1",
     "jest": "^29.7.0",
     "postcss": "^8.5.16",
-    "tailwind-merge": "^3.6.0",
     "tailwindcss": "^3.4.19",
     "ts-jest": "^29.2.5",
     "typescript": "^5.6.0"


### PR DESCRIPTION
These packages are used at build time in lib/utils.ts but were in devDependencies, causing Docker builds to fail when NODE_ENV=production (npm install skips devDeps).