### PR TITLE
fix(rayu-web): move tailwindcss, autoprefixer, postcss to dependencies

### DIFF
--- a/rayu-web/package.json
+++ b/rayu-web/package.json
@@ -14,26 +14,26 @@
   },
   "dependencies": {
     "@clerk/nextjs": "latest",
+    "autoprefixer": "^10.5.2",
     "clsx": "^2.1.1",
     "framer-motion": "^12.42.2",
     "lucide-react": "^1.23.0",
     "next": "^15.1.6",
+    "postcss": "^8.5.16",
     "qrcode.react": "^4.2.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-markdown": "^10.1.0",
     "remark-gfm": "^4.0.1",
-    "tailwind-merge": "^3.6.0"
+    "tailwind-merge": "^3.6.0",
+    "tailwindcss": "^3.4.19"
   },
   "devDependencies": {
     "@types/jest": "^29.5.14",
     "@types/node": "^20.19.0",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
-    "autoprefixer": "^10.5.2",
     "jest": "^29.7.0",
-    "postcss": "^8.5.16",
-    "tailwindcss": "^3.4.19",
     "ts-jest": "^29.2.5",
     "typescript": "^5.6.0"
   }


### PR DESCRIPTION
PostCSS runs during `next build` so tailwindcss, autoprefixer, and postcss must be in dependencies, not devDependencies. NODE_ENV=production in Docker causes npm to skip devDeps, breaking the CSS compilation step.