### PR TITLE
fix(macos): unbreak Enter in Apple Terminal when modifiers-napi is ab…

### DIFF
--- a/rayu/src/utils/modifiers.ts
+++ b/rayu/src/utils/modifiers.ts
@@ -1,6 +1,61 @@
 export type ModifierKey = 'shift' | 'command' | 'control' | 'option'
 
+/**
+ * Native macOS modifier-state reader, used only to emulate Shift+Enter in
+ * Apple Terminal (which cannot negotiate the Kitty keyboard / modifyOtherKeys
+ * protocols, so Shift+Enter is indistinguishable from Enter on the wire — see
+ * src/ink/terminal.ts EXTENDED_KEYS_TERMINALS, which deliberately omits it).
+ *
+ * `modifiers-napi` is OPTIONAL and is deliberately NOT bundled: all three
+ * bundlers list it in their `external` array (scripts/build.ts,
+ * build-binaries.ts, build-native.ts) so it survives as a runtime require and
+ * is resolved from disk only if present. It is not a package.json dependency,
+ * so on a normal install it is ABSENT and the require throws
+ * MODULE_NOT_FOUND. The contract documented in build.ts is "absent → caught by
+ * guards", so every access must degrade to "no modifier pressed" rather than
+ * throw.
+ *
+ * Why this matters (regression this file guards against): isModifierPressed()
+ * is called synchronously from useTextInput's handleEnter on EVERY Enter press
+ * in Apple Terminal, before onSubmit(). An unguarded require there threw on
+ * each keypress; the throw unwound the whole synchronous input dispatch into
+ * App.tsx's `handleReadable` catch, which keeps stdin alive but means
+ * onSubmit() is never reached. Typing kept working while Enter did nothing —
+ * a permanent, macOS-Terminal-only "frozen on Enter" hang. Linux/Windows never
+ * saw it because of the darwin check below, and iTerm/kitty/WezTerm/ghostty
+ * never saw it because the caller short-circuits on env.terminal.
+ */
+type ModifiersNative = {
+  prewarm?: () => void
+  isModifierPressed?: (modifier: string) => boolean
+}
+
+// undefined = load not attempted yet; null = attempted and unavailable.
+// Caching the failure keeps a missing module from costing a throwing
+// module-resolution on every single keystroke.
+let nativeModule: ModifiersNative | null | undefined
 let prewarmed = false
+
+/**
+ * Resolve the optional native module once. Returns null when it is missing or
+ * fails to initialize — never throws.
+ */
+function loadNativeModifiers(): ModifiersNative | null {
+  if (nativeModule !== undefined) {
+    return nativeModule
+  }
+  try {
+    // Kept as require() on purpose: a static import would defeat the
+    // `external` config above and make the bundle depend on a module that
+    // isn't shipped.
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    nativeModule = require('modifiers-napi') as ModifiersNative
+  } catch {
+    // Not installed for this platform/build — expected on every normal install.
+    nativeModule = null
+  }
+  return nativeModule
+}
 
 /**
  * Pre-warm the native module by loading it in advance.
@@ -11,11 +66,12 @@ export function prewarmModifiers(): void {
     return
   }
   prewarmed = true
-  // Load module in background
+  const native = loadNativeModifiers()
+  if (typeof native?.prewarm !== 'function') {
+    return
+  }
   try {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const { prewarm } = require('modifiers-napi') as { prewarm: () => void }
-    prewarm()
+    native.prewarm()
   } catch {
     // Ignore errors during prewarm
   }
@@ -23,14 +79,22 @@ export function prewarmModifiers(): void {
 
 /**
  * Check if a specific modifier key is currently pressed (synchronous).
+ *
+ * Returns false — "not pressed" — whenever the answer cannot be determined
+ * (non-darwin, module absent, native call failed). Callers treat this as a
+ * plain keypress, which is the safe default.
  */
 export function isModifierPressed(modifier: ModifierKey): boolean {
   if (process.platform !== 'darwin') {
     return false
   }
-  // Dynamic import to avoid loading native module at top level
-  const { isModifierPressed: nativeIsModifierPressed } =
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    require('modifiers-napi') as { isModifierPressed: (m: string) => boolean }
-  return nativeIsModifierPressed(modifier)
+  const native = loadNativeModifiers()
+  if (typeof native?.isModifierPressed !== 'function') {
+    return false
+  }
+  try {
+    return native.isModifierPressed(modifier) === true
+  } catch {
+    return false
+  }
 }

--- a/rayu/test/modifiers.test.ts
+++ b/rayu/test/modifiers.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Regression test for the macOS "frozen on Enter" hang.
+ *
+ * In Apple Terminal, useTextInput's handleEnter calls
+ * isModifierPressed('shift') synchronously on EVERY Enter press, before
+ * onSubmit() (src/hooks/useTextInput.ts:263). Apple Terminal cannot negotiate
+ * the Kitty keyboard / modifyOtherKeys protocols, so it is the only terminal
+ * that needs this native fallback to tell Shift+Enter from Enter.
+ *
+ * `modifiers-napi` is optional, is not a package.json dependency, and is listed
+ * as `external` by all three bundlers — so on a normal install it is ABSENT and
+ * require() throws MODULE_NOT_FOUND. Previously that throw was unguarded: every
+ * Enter threw, the throw unwound the synchronous input dispatch into App.tsx's
+ * handleReadable catch (which keeps stdin alive), and onSubmit() was never
+ * reached. Typing worked, Enter did nothing — permanently, on macOS Terminal
+ * only.
+ *
+ * These tests spoof process.platform to 'darwin' so the darwin-only branch is
+ * actually executed on Linux/CI, with the native module genuinely missing —
+ * exactly the shipped-install condition.
+ */
+import { afterEach, describe, expect, test } from 'bun:test'
+
+import {
+  type ModifierKey,
+  isModifierPressed,
+  prewarmModifiers,
+} from '../src/utils/modifiers.js'
+
+const REAL_PLATFORM = process.platform
+const ALL_MODIFIERS: ModifierKey[] = ['shift', 'command', 'control', 'option']
+
+function setPlatform(platform: string): void {
+  Object.defineProperty(process, 'platform', {
+    value: platform,
+    configurable: true,
+  })
+}
+
+afterEach(() => {
+  setPlatform(REAL_PLATFORM)
+})
+
+describe('isModifierPressed on macOS without the optional native module', () => {
+  test('returns false instead of throwing, so Enter can still submit', () => {
+    setPlatform('darwin')
+    // The assertion that matters: NOT throwing. A throw here is the hang.
+    expect(() => isModifierPressed('shift')).not.toThrow()
+    expect(isModifierPressed('shift')).toBe(false)
+  })
+
+  test('degrades the same way for every modifier', () => {
+    setPlatform('darwin')
+    for (const modifier of ALL_MODIFIERS) {
+      expect(() => isModifierPressed(modifier)).not.toThrow()
+      expect(isModifierPressed(modifier)).toBe(false)
+    }
+  })
+
+  test('stays quiet across many presses (the failed load must be cached)', () => {
+    setPlatform('darwin')
+    for (let i = 0; i < 100; i++) {
+      expect(isModifierPressed('shift')).toBe(false)
+    }
+  })
+
+  test('prewarmModifiers never throws either', () => {
+    setPlatform('darwin')
+    expect(() => prewarmModifiers()).not.toThrow()
+    // Idempotent: the internal guard means a second call is a no-op.
+    expect(() => prewarmModifiers()).not.toThrow()
+  })
+})
+
+describe('isModifierPressed off macOS', () => {
+  test('short-circuits to false without touching the native module', () => {
+    for (const platform of ['linux', 'win32']) {
+      setPlatform(platform)
+      expect(isModifierPressed('shift')).toBe(false)
+      expect(() => prewarmModifiers()).not.toThrow()
+    }
+  })
+})


### PR DESCRIPTION
…sent

Pressing Enter in macOS Terminal.app never submitted the prompt: typing kept working, but the input appeared frozen forever.

Root cause: Apple Terminal cannot negotiate the Kitty keyboard / modifyOtherKeys protocols (it is deliberately absent from EXTENDED_KEYS_TERMINALS in src/ink/terminal.ts), so Shift+Enter and Enter arrive as the same byte. To tell them apart, useTextInput's handleEnter calls isModifierPressed('shift') synchronously on every Enter press, before onSubmit(). That function did an unguarded require('modifiers-napi').

modifiers-napi is not a package.json dependency and is marked external by all three bundlers, so it survives into dist/rayu.js as a live runtime require and is absent on every normal install - the require threw MODULE_NOT_FOUND on each keypress. The throw unwound the whole synchronous input dispatch into App.tsx's handleReadable catch, which keeps stdin healthy (so typing still worked) but means onSubmit() was never reached.

Only macOS was affected: Linux/Windows return early on the darwin check before the require, and iTerm/kitty/WezTerm/ghostty short-circuit on the env.terminal === 'Apple_Terminal' test before reaching it. Startup was unaffected because prewarmModifiers() already wrapped the same require in a try/catch.

Fix: load the optional module through one cached, guarded loader shared by prewarmModifiers() and isModifierPressed(). A missing module, missing export, or throwing native call now degrades to false ("not pressed"), so Enter submits. The failed load is cached so a missing module does not cost a throwing module resolution on every keystroke. Kept as require() to preserve the external/DCE contract, restoring the "absent -> caught by guards" behaviour that scripts/build.ts documents and that the other four optional native modules already honour.

Known behaviour change: Shift+Enter no longer inserts a newline in Terminal.app. Nothing on the machine can detect it there, and the feature never worked on any shipped build since the module is not shipped. Use backslash+Enter or Option+Enter instead.

Tests: test/modifiers.test.ts spoofs process.platform to 'darwin' so the macOS-only branch executes on Linux CI with the module genuinely missing. Verified these tests fail (3/5) against the previous code with the exact production error, and pass (5/5) with the fix.

## Description
<!-- Provide a clear and concise description of your changes -->

## Related Issue
<!-- Link to the issue this PR addresses -->
Fixes #(issue number)

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test addition/modification

## Changes Made
<!-- List the specific changes you made -->
- 
- 
- 

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [ ] Tested locally with `bun run dev`
- [ ] All tests pass (`bun test`)
- [ ] Type checking passes (`bun run typecheck`)
- [ ] Tested on multiple providers (if applicable)
- [ ] Added new tests for new functionality

### Test Coverage
<!-- If applicable, describe test coverage -->
- New tests added: 
- Coverage maintained above 80%: [ ]

## Screenshots/Demo
<!-- If applicable, add screenshots or demo GIFs -->

## Checklist
- [ ] My code follows the project's code style
- [ ] I have performed a self-review of my code
- [ ] I have commented my code where needed
- [ ] I have updated the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing tests pass locally
- [ ] I have checked RAYU.md and AGENTS.md for CLI guidelines
- [ ] I have used `/graphify` to check for duplicate code
- [ ] I have updated CHANGELOG.md

## Breaking Changes
<!-- If this is a breaking change, describe the impact and migration path -->

## Additional Notes
<!-- Any additional information reviewers should know -->
